### PR TITLE
fix : 409 status code when add_bookmark now returns a boorkmark object

### DIFF
--- a/readability/api.py
+++ b/readability/api.py
@@ -353,9 +353,9 @@ class Readability(ReadabilityCore):
 
         r = self._post_resource(('bookmarks'), url=url, favorite=favorite, archive=archive)
 
-	# As 409 status code indicates an already bookmarked
-	# url, it should be considered as valid, and return
-	# the bookmark it points to.
+        # As 409 status code indicates an already bookmarked
+        # url, it should be considered as valid, and return
+        # the bookmark it points to.
         if r['status'] not in ('200','202', '409'):
             raise ResponseError('')
 
@@ -375,7 +375,7 @@ class APIError(Exception):
             self.msg = self.__doc__
         else:
             self.msg = msg
-            
+
         self.response = response
 
     def __str__(self):
@@ -383,7 +383,7 @@ class APIError(Exception):
             return "%s - response: %s" % (repr(self.msg), repr(self.response))
         else:
             return repr(self.msg)
-        
+
 class PermissionsError(APIError):
     """You do not have proper permission."""
 
@@ -398,6 +398,6 @@ class MissingError(APIError):
 
 class BadRequestError(APIError):
     """The request could not be understood due to bad syntax. Check your request and try again."""
-    
+
 class ServerError(APIError):
     """The server encountered an error and was unable to complete your request."""


### PR DESCRIPTION
I noticed that whether the documentation said that when a 409 status "should also provide a Location header to the resource in question", it was not the case when applying add_bookmark on an already processed url.

add_bookmark was raising an Error whenever the request status was not 200 or 202, instead of returning
the existing bookmark of corresponding to the requested Url; or at least it's location header.

Fixed it by adding the '409' status to the accepted add_bookmark requests status.
Now returns the already existing bookmark.
