### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,9 @@ Tests
 -----
 
 Valid Parser, Reader, username, and password must be set as environment
-variables before running the tests. This test suit runs agains the live
+variables before running the tests. This test suit runs against the live
 Readability API and also serves as integration tests. We recommend creating a
-seperate testing user account on Readability to avoid disturbing your reading
+separate testing user account on Readability to avoid disturbing your reading
 list. **Note:** These tests do reset the bookmarks library of the provided user
 when complete. They should *not* be run on your primary user account!
 

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -5,7 +5,7 @@ Authentication
 
     <a href="https://dev.twitter.com/oauth/3-legged" target="_blank">three-legged oAuth flow</a>
 
-Authentication can be accomplised through either a |three-legged-twitter| or
+Authentication can be accomplished through either a |three-legged-twitter| or
 via xAuth where a username and password are exchanged directly for a user token
 and secret.
 

--- a/readability/clients.py
+++ b/readability/clients.py
@@ -4,7 +4,7 @@
 readability.clients
 ~~~~~~~~~~~~~~~~~~~
 
-This module provies a client for the Reader API.
+This module provides a client for the Reader API.
 
 """
 

--- a/readability/utils.py
+++ b/readability/utils.py
@@ -96,7 +96,7 @@ def filter_args_to_dict(filter_dict, accepted_filter_keys=[]):
             # Going to skip it.
             continue
 
-        # map of casting funcitons to filter types
+        # map of casting functions to filter types
         filter_cast_map = {
             'int': cast_integer_filter,
             'datetime': cast_datetime_filter


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/auth.rst
- readability/clients.py
- readability/utils.py

Fixes:
- Should read `separate` rather than `seperate`.
- Should read `provides` rather than `provies`.
- Should read `functions` rather than `funcitons`.
- Should read `against` rather than `agains`.
- Should read `accomplished` rather than `accomplised`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md